### PR TITLE
Custom transformer functionality

### DIFF
--- a/Form/Type/Select2EntityType.php
+++ b/Form/Type/Select2EntityType.php
@@ -61,10 +61,22 @@ class Select2EntityType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        // add the appropriate data transformer
-        $transformer = $options['multiple']
-            ? new EntitiesToPropertyTransformer($this->em, $options['class'], $options['text_property'])
-            : new EntityToPropertyTransformer($this->em, $options['class'], $options['text_property']);
+        // add custom data transformer
+        if (!is_null($options['transformer'])) {
+            if (!is_string($options['transformer'])) {
+                throw new Exception('The option transformer must be a string');
+            }
+            if (!class_exists($options['transformer'])) {
+                throw new Exception('Unable to load class: '.$options['transformer']);
+            }
+            $transformer = new $options['transformer']($this->em, $options['class']);
+
+        // add the default data transformer
+        } else {
+            $transformer = $options['multiple']
+                ? new EntitiesToPropertyTransformer($this->em, $options['class'], $options['text_property'])
+                : new EntityToPropertyTransformer($this->em, $options['class'], $options['text_property']);
+        }
 
         $builder->addViewTransformer($transformer, true);
     }
@@ -117,7 +129,8 @@ class Select2EntityType extends AbstractType
                 'placeholder' => '',
                 'language' => $this->language,
                 'required' => false,
-                'cache' => $this->cache
+                'cache' => $this->cache,
+                'transformer' => null,
             )
         );
     }

--- a/Form/Type/Select2EntityType.php
+++ b/Form/Type/Select2EntityType.php
@@ -76,7 +76,7 @@ class Select2EntityType extends AbstractType
                 ? ($transformer instanceof EntitiesToPropertyTransformer)
                 : ($transformer instanceof EntityToPropertyTransformer);
             if (!$isValidType) {
-                throw new Exception(sprintf('The custom transformer %s must extend %s', get_class($transformer), $options['multiple'] ? EntitiesToPropertyTransformer::class : EntityToPropertyTransformer::class);
+                throw new \Exception(sprintf('The custom transformer %s must extend %s', get_class($transformer), $options['multiple'] ? EntitiesToPropertyTransformer::class : EntityToPropertyTransformer::class));
             }
 
         // add the default data transformer

--- a/Form/Type/Select2EntityType.php
+++ b/Form/Type/Select2EntityType.php
@@ -62,14 +62,22 @@ class Select2EntityType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         // add custom data transformer
-        if (!is_null($options['transformer'])) {
+        if ($options['transformer']) {
             if (!is_string($options['transformer'])) {
-                throw new Exception('The option transformer must be a string');
+                throw new \Exception('The option transformer must be a string');
             }
             if (!class_exists($options['transformer'])) {
-                throw new Exception('Unable to load class: '.$options['transformer']);
+                throw new \Exception('Unable to load class: '.$options['transformer']);
             }
+
             $transformer = new $options['transformer']($this->em, $options['class']);
+
+            $isValidType = $options['multiple']
+                ? ($transformer instanceof EntitiesToPropertyTransformer)
+                : ($transformer instanceof EntityToPropertyTransformer);
+            if (!$isValidType) {
+                throw new Exception(sprintf('The custom transformer %s must extend %s', get_class($transformer), $options['multiple'] ? EntitiesToPropertyTransformer::class : EntityToPropertyTransformer::class);
+            }
 
         // add the default data transformer
         } else {

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The controller should return a `JSON` array in the following format. The propert
 ```
 
 ##Custom template##
-If you need custom view that is a combination between few fields in the entity, you need a custom transformer. For that, extend EntityToPropertyTransformer or EntitiesToPropertyTransformer, redefine function transform and set the custom content.
+If you need custom view that is a combination between more than one field in the entity, you need a custom transformer. For that, extend EntityToPropertyTransformer or EntitiesToPropertyTransformer, redefine function transform and set the custom content.
 
 Here's an example, that shows country name and continent (two different properties in Country entity):
 ```php

--- a/README.md
+++ b/README.md
@@ -146,16 +146,24 @@ Here's an example that returns the country name and continent (two different pro
 ```php
 $builder
     ->add('country', Select2EntityType::class, [
-        'multiple' => false,
+        'multiple' => true,
         'remote_route' => 'tetranz_test_default_countryquery',
         'class' => '\Tetranz\TestBundle\Entity\Country',
-        'transformer' => '\Tetranz\TestBundle\Form\DataTransformer\CountryEntityToPropertyTransformer',
+        'transformer' => '\Tetranz\TestBundle\Form\DataTransformer\CountryEntitiesToPropertyTransformer',
     ]);
+```
+In transform sets data array like this:
+```php
+$data[] = array(
+    'id' => $country->getId(),
+    'text' => $country->getName().' ('.$country->getContinent()->getName().')',
+);
 ```
 Your custom transformer and respectively your Ajax controller should return an array in the following format:
 ```javascript
 [ 
-    { id: 1, text: 'United Kingdom (Europe)' }
+    { id: 1, text: 'United Kingdom (Europe)' },
+    { id: 1, text: 'China (Asia)' }
 ]
 ```
 
@@ -167,20 +175,21 @@ Again you'll need custom transformer as in the example above:
 ```php
 $builder
     ->add('country', Select2EntityType::class, [
-        'multiple' => false,
+        'multiple' => true,
         'remote_route' => 'tetranz_test_default_countryquery',
         'class' => '\Tetranz\TestBundle\Entity\Country',
-        'transformer' => '\Tetranz\TestBundle\Form\DataTransformer\CountryEntityToPropertyTransformer',
+        'transformer' => '\Tetranz\TestBundle\Form\DataTransformer\CountryEntitiesToPropertyTransformer',
     ]);
 ```
 
 Your custom transformer should return data like this:
 ```javascript
 [ 
-    { id: 1, text: 'United Kingdom (Europe)', img: 'vendor/images/flags/en.png' }
+    { id: 1, text: 'United Kingdom (Europe)', img: 'images/flags/en.png' },
+    { id: 2, text: 'China (Asia)', img: 'images/flags/ch.png' }
 ]
 ```
-You will need this additional JavaScript. You need to define your own fuction `select2entityAjax` which calls the original one and display dustom template with image:
+You need to define your own JavaScript fuction `select2entityAjax` which extends the original one `select2entity` and display custom template with image:
 ```javascript
 $.fn.select2entityAjax = function(action) {
     var action = action || {};
@@ -205,20 +214,18 @@ $.fn.select2entityAjax = function(action) {
 };
 $('.select2entity').select2entityAjax();
 ```
-This script will add the functionality globally for all '.select2entity' elements, but if the `img` is not passed will work as the origina one - `select2entity`.
+This script will add the functionality globally for all elements with class `select2entity`, but if the `img` is not passed it will work as the original `select2entity`.
 
 You also will need to override following block in your template:
 ```twig
 {% block tetranz_select2entity_widget_select_option %}
     <option value="{{ label.id }}" data-img="{{ label.img }}" selected="selected">{{ label.text }}</option>
 {% endblock %}
-Here you need to add all additional data needed to the JavaScript function `select2entityAjax`, like data attribute
 ```
+This block adds all additional data needed to the JavaScript function `select2entityAjax`, like data attribute. In this case we are passing `data-img`.
 
 ##Embed Collection Forms##
-If you use [Embed Collection Forms](http://symfony.com/doc/current/cookbook/form/form_collections.html) and [data-prototype](http://symfony.com/doc/current/cookbook/form/form_collections.html#allowing-new-tags-with-the-prototype) to add new elements in the form.
-
-You will need the following JavaScript:
+If you use [Embed Collection Forms](http://symfony.com/doc/current/cookbook/form/form_collections.html) and [data-prototype](http://symfony.com/doc/current/cookbook/form/form_collections.html#allowing-new-tags-with-the-prototype) to add new elements in the form. You will need the following JavaScript that will listen for adding an element `.select2entity`:
 ```javascript
 $('body').on('click', '[data-prototype]', function(e) {
     $(this).prev().find('.select2entity').last().select2entity();

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 select2entity-bundle
 ====================
 
+##Fork description##
+
+
 ##Introduction##
 
 This is a Symfony2 bundle which enables the popular [Select2](https://select2.github.io) component to be used as a drop-in replacement for a standard entity field on a Symfony form.

--- a/README.md
+++ b/README.md
@@ -100,68 +100,6 @@ Put this at the top of the file with the form type class:
 use Tetranz\Select2EntityBundle\Form\Type\Select2EntityType;
 ```
 
-If you need custom view that is a combination between few fields in the entity, you need custom transformer. For that, extend EntityToPropertyTransformer or EntitiesToPropertyTransformer, redefine function transform and set the custom content.
-
-Here's an example:
-```php
-$builder
-    ->add('country', Select2EntityType::class, [
-        'multiple' => false,
-        'remote_route' => 'tetranz_test_default_countryquery',
-        'class' => '\Tetranz\TestBundle\Entity\Country',
-        'transformer' => '\Tetranz\TestBundle\Form\DataTransformer\CountryEntityToPropertyTransformer',
-    ]);
-```
-And you could display data like this:
-```javascript
-[
-    { id: 1, text: 'United Kingdom (Europe)' },
-    { id: 2, text: 'China (Asia)' }
-]
-```
-
-You could display images, if your custom transformer returns data like this:
-```javascript
-[
-    { id: 1, text: 'United Kingdom (Europe)', img: 'vendor/images/flags/en.png' },
-    { id: 2, text: 'China (Asia)', img: 'vendor/images/flags/ch.png' }
-]
-```
-You will need this additional JavaScript to display images:
-```javascript
-$.fn.select2entityAjax = function(action) {
-    var action = action || {};
-    var template = function (item) {
-        var img = item.img || null;
-        if (!img) {
-            if (item.element && item.element.dataset.img) {
-                img = item.element.dataset.img;
-            } else {
-                return item.text;
-            }
-        }
-        return $(
-            '<span><img src="' + img + '" class="img-circle img-sm"> ' + item.text + '</span>'
-        );
-    };
-    this.select2entity($.extend(action, {
-        templateResult: template,
-        templateSelection: template
-    }));
-    return this;
-};
-$('.select2entity').select2entityAjax();
-```
-The script will add the functionality globally for all '.select2entity' elements.
-You also will need to override following block in your template:
-```twig
-{% block tetranz_select2entity_widget_select_options %}
-    {% if value and value is iterable %}
-        <option value="{{ value.id }}" data-img="{{ value.img }}" selected="selected">{{ value.text }}</option>
-    {% endif %}
-{% endblock %}
-```
-
 ##Options##
 Defaults will be used for some if not set.
 * `class` is your entity class. Required
@@ -199,6 +137,65 @@ The controller should return a `JSON` array in the following format. The propert
   { id: 1, text: 'Displayed Text 1' },
   { id: 2, text: 'Displayed Text 2' }
 ]
+```
+
+##Custom template##
+If you need custom view that is a combination between few fields in the entity, you need a custom transformer. For that, extend EntityToPropertyTransformer or EntitiesToPropertyTransformer, redefine function transform and set the custom content.
+
+Here's an example, that shows country name and continent (two different properties in Country entity):
+```php
+$builder
+    ->add('country', Select2EntityType::class, [
+        'multiple' => false,
+        'remote_route' => 'tetranz_test_default_countryquery',
+        'class' => '\Tetranz\TestBundle\Entity\Country',
+        'transformer' => '\Tetranz\TestBundle\Form\DataTransformer\CountryEntityToPropertyTransformer',
+    ]);
+```
+Your custom transformer and respectively your Ajax controller should return a array in the following format:
+```javascript
+[ id: 1, text: 'United Kingdom (Europe)' ]
+```
+
+If you need [Templating](https://select2.github.io/examples.html#templating) in Select2, you could consider following example.
+Your custom transformer could return data like this:
+```javascript
+[ id: 1, text: 'United Kingdom (Europe)', img: 'vendor/images/flags/en.png' ]
+```
+You will need this additional JavaScript to display images:
+```javascript
+$.fn.select2entityAjax = function(action) {
+    var action = action || {};
+    var template = function (item) {
+        var img = item.img || null;
+        if (!img) {
+            if (item.element && item.element.dataset.img) {
+                img = item.element.dataset.img;
+            } else {
+                return item.text;
+            }
+        }
+        return $(
+            '<span><img src="' + img + '" class="img-circle img-sm"> ' + item.text + '</span>'
+        );
+    };
+    this.select2entity($.extend(action, {
+        templateResult: template,
+        templateSelection: template
+    }));
+    return this;
+};
+$('.select2entity').select2entityAjax();
+```
+This script will add the functionality globally for all '.select2entity' elements!
+
+You also will need to override following block in your template:
+```twig
+{% block tetranz_select2entity_widget_select_options %}
+    {% if value and value is iterable %}
+        <option value="{{ value.id }}" data-img="{{ value.img }}" selected="selected">{{ value.text }}</option>
+    {% endif %}
+{% endblock %}
 ```
 
 ##How to use it with Embed Collection Forms##

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ The controller should return a `JSON` array in the following format. The propert
 ]
 ```
 
-##Custom text##
-If you need to display more than one field from the entity, you need to define your own custom transformer. For that, extend EntityToPropertyTransformer or EntitiesToPropertyTransformer and redefine the transform method. This way you can return as `text` anything you want, not just one entity property.
+##Custom option text##
+If you need more flexibility in what you display as the text for each option, such as displaying the values of several fields from your entity or showing an image inside, you may define your own custom transformer. For that, extend EntityToPropertyTransformer or EntitiesToPropertyTransformer and redefine the transform() method. This way you can return as `text` anything you want, not just one entity property.
 
 Here's an example that returns the country name and continent (two different properties in the Country entity):
 ```php
@@ -167,20 +167,9 @@ Your custom transformer and respectively your Ajax controller should return an a
 ]
 ```
 
-##Templating##
+###Templating###
 
-If you need [Templating](https://select2.github.io/examples.html#templating) in Select2, you could consider the following example, that shows the contry flag in the beging.
-
-Again you'll need custom transformer as in the example above: 
-```php
-$builder
-    ->add('country', Select2EntityType::class, [
-        'multiple' => true,
-        'remote_route' => 'tetranz_test_default_countryquery',
-        'class' => '\Tetranz\TestBundle\Entity\Country',
-        'transformer' => '\Tetranz\TestBundle\Form\DataTransformer\CountryEntitiesToPropertyTransformer',
-    ]);
-```
+If you need [Templating](https://select2.github.io/examples.html#templating) in Select2, you could consider the following example that shows the country flag next to each option.
 
 Your custom transformer should return data like this:
 ```javascript
@@ -216,7 +205,7 @@ $('.select2entity').select2entityAjax();
 ```
 This script will add the functionality globally for all elements with class `select2entity`, but if the `img` is not passed it will work as the original `select2entity`.
 
-You also will need to override following block in your template:
+You also will need to override the following block in your template:
 ```twig
 {% block tetranz_select2entity_widget_select_option %}
     <option value="{{ label.id }}" data-img="{{ label.img }}" selected="selected">{{ label.text }}</option>
@@ -225,7 +214,7 @@ You also will need to override following block in your template:
 This block adds all additional data needed to the JavaScript function `select2entityAjax`, like data attribute. In this case we are passing `data-img`.
 
 ##Embed Collection Forms##
-If you use [Embed Collection Forms](http://symfony.com/doc/current/cookbook/form/form_collections.html) and [data-prototype](http://symfony.com/doc/current/cookbook/form/form_collections.html#allowing-new-tags-with-the-prototype) to add new elements in the form. You will need the following JavaScript that will listen for adding an element `.select2entity`:
+If you use [Embedded Collection Forms](http://symfony.com/doc/current/cookbook/form/form_collections.html) and [data-prototype](http://symfony.com/doc/current/cookbook/form/form_collections.html#allowing-new-tags-with-the-prototype) to add new elements in your form, you will need the following JavaScript that will listen for adding an element `.select2entity`:
 ```javascript
 $('body').on('click', '[data-prototype]', function(e) {
     $(this).prev().find('.select2entity').last().select2entity();

--- a/README.md
+++ b/README.md
@@ -208,7 +208,12 @@ This script will add the functionality globally for all elements with class `sel
 You also will need to override the following block in your template:
 ```twig
 {% block tetranz_select2entity_widget_select_option %}
-    <option value="{{ label.id }}" data-img="{{ label.img }}" selected="selected">{{ label.text }}</option>
+    <option value="{{ label.id }}" selected="selected"
+            {% for key, data in label %}
+                {% if key not in ['id', 'text'] %} data-{{ key }}="{{ data }}"{% endif %}
+            {% endfor %}>
+        {{ label.text }}
+    </option>
 {% endblock %}
 ```
 This block adds all additional data needed to the JavaScript function `select2entityAjax`, like data attribute. In this case we are passing `data-img`.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,9 @@ Your custom transformer and respectively your Ajax controller should return a ar
 [ id: 1, text: 'United Kingdom (Europe)' ]
 ```
 
+
 If you need [Templating](https://select2.github.io/examples.html#templating) in Select2, you could consider following example.
+
 Your custom transformer could return data like this:
 ```javascript
 [ id: 1, text: 'United Kingdom (Europe)', img: 'vendor/images/flags/en.png' ]
@@ -193,7 +195,13 @@ You also will need to override following block in your template:
 ```twig
 {% block tetranz_select2entity_widget_select_options %}
     {% if value and value is iterable %}
-        <option value="{{ value.id }}" data-img="{{ value.img }}" selected="selected">{{ value.text }}</option>
+        {% if multiple %}
+            {% for label in value %}
+                <option value="{{ label.id }}" data-img="{{ label.img }}" selected="selected">{{ label.text }}</option>
+            {% endfor %}
+        {% else %}
+            <option value="{{ value.id }}" data-img="{{ value.img }}" selected="selected">{{ value.text }}</option>
+        {% endif %}
     {% endif %}
 {% endblock %}
 ```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 select2entity-bundle
 ====================
 
-##Fork description##
-
-
 ##Introduction##
 
 This is a Symfony2 bundle which enables the popular [Select2](https://select2.github.io) component to be used as a drop-in replacement for a standard entity field on a Symfony form.

--- a/README.md
+++ b/README.md
@@ -139,10 +139,10 @@ The controller should return a `JSON` array in the following format. The propert
 ]
 ```
 
-##Custom template##
-If you need custom view that is a combination between more than one field in the entity, you need a custom transformer. For that, extend EntityToPropertyTransformer or EntitiesToPropertyTransformer, redefine function transform and set the custom content.
+##Custom text##
+If you need to display more than one field from the entity, you need to define your own custom transformer. For that, extend EntityToPropertyTransformer or EntitiesToPropertyTransformer and redefine the transform method. This way you can return as `text` anything you want, not just one entity property.
 
-Here's an example, that shows country name and continent (two different properties in Country entity):
+Here's an example that returns the country name and continent (two different properties in the Country entity):
 ```php
 $builder
     ->add('country', Select2EntityType::class, [
@@ -152,19 +152,35 @@ $builder
         'transformer' => '\Tetranz\TestBundle\Form\DataTransformer\CountryEntityToPropertyTransformer',
     ]);
 ```
-Your custom transformer and respectively your Ajax controller should return a array in the following format:
+Your custom transformer and respectively your Ajax controller should return an array in the following format:
 ```javascript
-[ id: 1, text: 'United Kingdom (Europe)' ]
+[ 
+    { id: 1, text: 'United Kingdom (Europe)' }
+]
 ```
 
+##Templating##
 
-If you need [Templating](https://select2.github.io/examples.html#templating) in Select2, you could consider following example.
+If you need [Templating](https://select2.github.io/examples.html#templating) in Select2, you could consider the following example, that shows the contry flag in the beging.
 
-Your custom transformer could return data like this:
-```javascript
-[ id: 1, text: 'United Kingdom (Europe)', img: 'vendor/images/flags/en.png' ]
+Again you'll need custom transformer as in the example above: 
+```php
+$builder
+    ->add('country', Select2EntityType::class, [
+        'multiple' => false,
+        'remote_route' => 'tetranz_test_default_countryquery',
+        'class' => '\Tetranz\TestBundle\Entity\Country',
+        'transformer' => '\Tetranz\TestBundle\Form\DataTransformer\CountryEntityToPropertyTransformer',
+    ]);
 ```
-You will need this additional JavaScript to display images:
+
+Your custom transformer should return data like this:
+```javascript
+[ 
+    { id: 1, text: 'United Kingdom (Europe)', img: 'vendor/images/flags/en.png' }
+]
+```
+You will need this additional JavaScript. You need to define your own fuction `select2entityAjax` which calls the original one and display dustom template with image:
 ```javascript
 $.fn.select2entityAjax = function(action) {
     var action = action || {};
@@ -189,20 +205,22 @@ $.fn.select2entityAjax = function(action) {
 };
 $('.select2entity').select2entityAjax();
 ```
-This script will add the functionality globally for all '.select2entity' elements!
+This script will add the functionality globally for all '.select2entity' elements, but if the `img` is not passed will work as the origina one - `select2entity`.
 
 You also will need to override following block in your template:
 ```twig
 {% block tetranz_select2entity_widget_select_option %}
     <option value="{{ label.id }}" data-img="{{ label.img }}" selected="selected">{{ label.text }}</option>
 {% endblock %}
+Here you need to add all additional data needed to the JavaScript function `select2entityAjax`, like data attribute
 ```
 
-##How to use it with Embed Collection Forms##
-If you use [Embed Collection Forms](http://symfony.com/doc/current/cookbook/form/form_collections.html) you will need this JavaScript:
+##Embed Collection Forms##
+If you use [Embed Collection Forms](http://symfony.com/doc/current/cookbook/form/form_collections.html) and [data-prototype](http://symfony.com/doc/current/cookbook/form/form_collections.html#allowing-new-tags-with-the-prototype) to add new elements in the form.
+
+You will need the following JavaScript:
 ```javascript
 $('body').on('click', '[data-prototype]', function(e) {
     $(this).prev().find('.select2entity').last().select2entity();
 });
 ```
-That will work if you use [data-prototype](http://symfony.com/doc/current/cookbook/form/form_collections.html#allowing-new-tags-with-the-prototype) to add new elements in the form.

--- a/README.md
+++ b/README.md
@@ -193,16 +193,8 @@ This script will add the functionality globally for all '.select2entity' element
 
 You also will need to override following block in your template:
 ```twig
-{% block tetranz_select2entity_widget_select_options %}
-    {% if value and value is iterable %}
-        {% if multiple %}
-            {% for label in value %}
-                <option value="{{ label.id }}" data-img="{{ label.img }}" selected="selected">{{ label.text }}</option>
-            {% endfor %}
-        {% else %}
-            <option value="{{ value.id }}" data-img="{{ value.img }}" selected="selected">{{ value.text }}</option>
-        {% endif %}
-    {% endif %}
+{% block tetranz_select2entity_widget_select_option %}
+    <option value="{{ label.id }}" data-img="{{ label.img }}" selected="selected">{{ label.text }}</option>
 {% endblock %}
 ```
 

--- a/Resources/public/js/select2entity.js
+++ b/Resources/public/js/select2entity.js
@@ -1,10 +1,7 @@
 $(document).ready(function () {
   $.fn.select2entity = function(action) {
-    if(action){
-      this.select2(action);
-      return this;
-    }
-    this.select2({
+    var action = action || {};
+    this.select2($.extend(action, {
       ajax: {
         data: function (params) {
           return {
@@ -17,7 +14,7 @@ $(document).ready(function () {
           };
         }
       }
-    });
+    }));
     return this;
   };
 

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -20,11 +20,13 @@
 
     {% spaceless %}
         <select {{ block('widget_attributes') }}>
-            {% if value is iterable %}
-                {% for id, label in value %}
-                    <option value="{{ id }}" selected="selected">{{ label }}</option>
-                {% endfor %}
-            {% endif %}
+            {% block tetranz_select2entity_widget_select_options %}
+                {% if value is iterable %}
+                    {% for id, label in value %}
+                        <option value="{{ id }}" selected="selected">{{ label }}</option>
+                    {% endfor %}
+                {% endif %}
+            {% endblock %}
         </select>
     {% endspaceless %}
 {% endblock %}

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -20,13 +20,13 @@
 
     {% spaceless %}
         <select {{ block('widget_attributes') }}>
-            {% block tetranz_select2entity_widget_select_options %}
-                {% if value is iterable %}
-                    {% for id, label in value %}
+            {% if value is iterable %}
+                {% for id, label in value %}
+                    {% block tetranz_select2entity_widget_select_option %}
                         <option value="{{ id }}" selected="selected">{{ label }}</option>
-                    {% endfor %}
-                {% endif %}
-            {% endblock %}
+                    {% endblock %}
+                {% endfor %}
+            {% endif %}
         </select>
     {% endspaceless %}
 {% endblock %}


### PR DESCRIPTION
- Adding custom transformer functionality allowing to have custom text that can display more than one entity property. 

- Adding support for custom templates for the option text, which allows for adding option images.

- Updated README with the new additions.