### PR TITLE
Add PHP requirement in composer.json

### DIFF
--- a/Form/Type/Select2EntityType.php
+++ b/Form/Type/Select2EntityType.php
@@ -74,7 +74,7 @@ class Select2EntityType extends AbstractType
             $transformer = new $options['transformer']($this->em, $options['class']);
 
             if (!$transformer instanceof DataTransformerInterface) {
-                throw new \Exception(sprintf('The custom transformer %s must implement %s', get_class($transformer), DataTransformerInterface::class));
+                throw new \Exception(sprintf('The custom transformer %s must implement "Symfony\Component\Form\DataTransformerInterface"', get_class($transformer)));
             }
 
         // add the default data transformer

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.4.0",
         "symfony/symfony": ">=2.2",
         "doctrine/orm": ">=2.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         }
     ],
     "require": {
+        "php": ">=5.5.0",
         "symfony/symfony": ">=2.2",
         "doctrine/orm": ">=2.2"
     },


### PR DESCRIPTION
Because of a class name resolution with `::class`, we need to add a restriction on PHP version in Composer.

Current composer definition allow to install the bundle with PHP 5.4 for example.