### PR TITLE
Implemented 'Caching'.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,6 +28,10 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('delay')->defaultValue(250)->end()
                     ->scalarNode('language')->defaultValue('en')->end()
                     ->scalarNode('cache')->defaultTrue()->end()
+                    // default to 1ms for backwards compatibility for older versions where 'cache' is true but the
+                    // user is not aware of the updated caching feature. This way the cache will, by default, not
+                    // be very effective. Realistically this should be like 60000ms (60 seconds).
+                    ->scalarNode('cache_timeout')->defaultValue(1)->end()
                 ->end();
 
         // Here you should define the parameters that are allowed to

--- a/DependencyInjection/TetranzSelect2EntityExtension.php
+++ b/DependencyInjection/TetranzSelect2EntityExtension.php
@@ -22,12 +22,7 @@ class TetranzSelect2EntityExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        // set parameters with these settings so they'll be available in the service definition xml
-        $varNames = ['minimum_input_length', 'page_limit', 'allow_clear', 'delay', 'language', 'cache'];
-
-        foreach($varNames as $varName) {
-            $container->setParameter("tetranz_select2_entity.$varName", $config[$varName]);
-        }
+        $container->setParameter("tetranz_select2_entity.config", $config);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');

--- a/Form/Type/Select2EntityType.php
+++ b/Form/Type/Select2EntityType.php
@@ -74,7 +74,7 @@ class Select2EntityType extends AbstractType
         $view->vars['remote_path'] = $options['remote_path']
             ?: $this->router->generate($options['remote_route'], array_merge($options['remote_params'], [ 'page_limit' => $options['page_limit'] ]));
 
-        $varNames = array('multiple', 'placeholder', 'primary_key', 'allow_clear', 'minimum_input_length') + array_keys($this->config);
+        $varNames = array_merge(array('multiple', 'placeholder', 'primary_key'), array_keys($this->config));
         foreach ($varNames as $varName) {
             $view->vars[$varName] = $options[$varName];
         }

--- a/Form/Type/Select2EntityType.php
+++ b/Form/Type/Select2EntityType.php
@@ -74,7 +74,7 @@ class Select2EntityType extends AbstractType
         $view->vars['remote_path'] = $options['remote_path']
             ?: $this->router->generate($options['remote_route'], array_merge($options['remote_params'], [ 'page_limit' => $options['page_limit'] ]));
 
-        $varNames = array('multiple', 'placeholder', 'primary_key', 'allow_clear') + array_keys($this->config);
+        $varNames = array('multiple', 'placeholder', 'primary_key', 'allow_clear', 'minimum_input_length') + array_keys($this->config);
         foreach ($varNames as $varName) {
             $view->vars[$varName] = $options[$varName];
         }

--- a/Form/Type/Select2EntityType.php
+++ b/Form/Type/Select2EntityType.php
@@ -23,41 +23,21 @@ class Select2EntityType extends AbstractType
 {
     /** @var EntityManagerInterface */
     protected $em;
-    /** @var Router */
+    /** @var RouterInterface */
     protected $router;
-    /** @var  integer */
-    protected $pageLimit;
-    /** @var  integer */
-    protected $minimumInputLength;
-    /** @var  boolean */
-    protected $allowClear;
-    /** @var  integer */
-    protected $delay;
-    /** @var  string */
-    protected $language;
-    /** @var  boolean */
-    protected $cache;
+    /** @var  array */
+    protected $config;
 
     /**
      * @param EntityManagerInterface $em
-     * @param RouterInterface $router
-     * @param integer $minimumInputLength
-     * @param integer $pageLimit
-     * @param boolean $allowClear
-     * @param integer $delay
-     * @param string $language
-     * @param boolean $cache
+     * @param RouterInterface        $router
+     * @param array                  $config
      */
-    public function __construct(EntityManagerInterface $em, RouterInterface $router, $minimumInputLength, $pageLimit, $allowClear, $delay, $language, $cache)
+    public function __construct(EntityManagerInterface $em, RouterInterface $router, $config)
     {
         $this->em = $em;
         $this->router = $router;
-        $this->minimumInputLength = $minimumInputLength;
-        $this->pageLimit = $pageLimit;
-        $this->allowClear = $allowClear;
-        $this->delay = $delay;
-        $this->language = $language;
-        $this->cache = $cache;
+        $this->config = $config;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
@@ -94,7 +74,7 @@ class Select2EntityType extends AbstractType
         $view->vars['remote_path'] = $options['remote_path']
             ?: $this->router->generate($options['remote_route'], array_merge($options['remote_params'], [ 'page_limit' => $options['page_limit'] ]));
 
-        $varNames = array('multiple', 'minimum_input_length', 'placeholder', 'language', 'allow_clear', 'delay', 'language', 'cache', 'primary_key');
+        $varNames = array('multiple', 'placeholder', 'primary_key', 'allow_clear') + array_keys($this->config);
         foreach ($varNames as $varName) {
             $view->vars[$varName] = $options[$varName];
         }
@@ -128,15 +108,16 @@ class Select2EntityType extends AbstractType
                 'remote_params' => array(),
                 'multiple' => false,
                 'compound' => false,
-                'minimum_input_length' => $this->minimumInputLength,
-                'page_limit' => $this->pageLimit,
-                'allow_clear' => $this->allowClear,
-                'delay' => $this->delay,
+                'minimum_input_length' => $this->config['minimum_input_length'],
+                'page_limit' => $this->config['page_limit'],
+                'allow_clear' => $this->config['allow_clear'],
+                'delay' => $this->config['delay'],
                 'text_property' => null,
                 'placeholder' => '',
-                'language' => $this->language,
+                'language' => $this->config['language'],
                 'required' => false,
-                'cache' => $this->cache,
+                'cache' => $this->config['cache'],
+                'cache_timeout' => $this->config['cache_timeout'],
                 'transformer' => null,
             )
         );

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ $builder
             'allow_clear' => true,
             'delay' => 250,
             'cache' => true,
+            'cache_timeout' => 60000, // if 'cache' is true
             'language' => 'en',
             'placeholder' => 'Select a country',
         ])
@@ -114,7 +115,8 @@ If text_property is omitted then the entity is cast to a string. This requires i
 * `delay` The delay in milliseconds after a keystroke before trigging another AJAX request. Defaults to 250 ms.
 * `placeholder` Placeholder text.
 * `language` i18n language code. Defaults to en.
-* `cache` Enable AJAX cache. The use of this is a little unclear at Select2. Defaults to true as per Select2 examples.
+* `cache` Enable AJAX cache. Results will be cached for each 'term' queried.
+* `cache_timeout` How long to cache a query in milliseconds. Setting to `0` will cause the cache to never timeout _(60000 = 60 seconds)_
 * `transformer` The fully qualified class name of a custom transformer if you need that flexibility as described below.
 
 The url of the remote query can be given by either of two ways: `remote_route` is the Symfony route. `remote_params` can be optionally specified to provide parameters. Alternatively, `remote_path` can be used to specify the url directly.
@@ -129,6 +131,7 @@ tetranz_select2_entity:
     delay: 500
     language: fr
     cache: false
+    cache_timeout: 0
 ```
 
 ##AJAX Response##

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -9,12 +9,7 @@
             <tag name="form.type" alias="tetranz_select2entity" />
             <argument type="service" id="doctrine.orm.entity_manager" />
             <argument type="service" id="router" />
-            <argument>%tetranz_select2_entity.minimum_input_length%</argument>
-            <argument>%tetranz_select2_entity.page_limit%</argument>
-            <argument>%tetranz_select2_entity.allow_clear%</argument>
-            <argument>%tetranz_select2_entity.delay%</argument>
-            <argument>%tetranz_select2_entity.language%</argument>
-            <argument>%tetranz_select2_entity.cache%</argument>
+            <argument>%tetranz_select2_entity.config%</argument>
         </service>
     </services>
 

--- a/Resources/public/js/select2entity.js
+++ b/Resources/public/js/select2entity.js
@@ -1,22 +1,49 @@
 $(document).ready(function () {
-  $.fn.select2entity = function(action) {
-    var action = action || {};
-    this.select2($.extend(action, {
-      ajax: {
-        data: function (params) {
-          return {
-            q: params.term
-          };
-        },
-        processResults: function (data) {
-          return {
-            results: data
-          };
-        }
-      }
-    }));
-    return this;
-  };
+    $.fn.select2entity = function (options) {
+        this.each(function () {
+            // Keep a reference to the element so we can keep the cache local to this instance and so we can
+            // determine if caching is even enabled on this element by looking at it's data attributes since select2
+            // doesn't expose its options to the transport method.
+            var $s2 = $(this), cache = [];
+            $s2.select2($.extend({
+                ajax: {
+                    transport: function (params, success, failure) {
+                        // is caching enabled?
+                        if ($s2.data('ajax--cache')) {
+                            var key = params.data.q, cacheTimeout = $s2.data('ajax--cacheTimeout');
+                            // no cache entry for 'term' or the cache has timed out?
+                            if (typeof cache[key] == 'undefined' || (cacheTimeout && Date.now() >= cache[key].time)) {
+                                $.ajax(params).fail(failure).done(function (data) {
+                                    cache[key] = {
+                                        data: data,
+                                        time: cacheTimeout ? Date.now() + cacheTimeout : null
+                                    };
+                                    success(data);
+                                });
+                            } else {
+                                // return cached data with no ajax request
+                                success(cache[key].data);
+                            }
+                        } else {
+                            // no caching enabled. just do the ajax request
+                            $.ajax(params).fail(failure).done(success);
+                        }
+                    },
+                    data: function (params) {
+                        return {
+                            q: params.term
+                        };
+                    },
+                    processResults: function (data) {
+                        return {
+                            results: data
+                        };
+                    }
+                }
+            }, options || {}));
+        });
+        return this;
+    };
 
-  $('.select2entity').select2entity();
+    $('.select2entity').select2entity();
 });

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -2,6 +2,7 @@
     {% set attr = attr|merge({
     'data-ajax--url':remote_path,
     'data-ajax--cache': cache ? 'true' : 'false',
+    'data-ajax--cache-timeout': cache_timeout|default(0),
     'data-ajax--delay':delay,
     'data-ajax--data-type':"json",
     'data-language':language,


### PR DESCRIPTION
The default 'cache' option is normally just passed to the $.ajax command to help prevent browsers from caching GET requests, etc. That doesn't help us cache requests in to prevent multiple repetitive lookups.

I implemented a true 'per term' cache. So each term you enter is cached. Each cache can have a max age limit. By default I left it at 1ms, because the current 'cache' option defaults to true we don't want to change the known behavior for existing users. Simply change the `cache_timeout` option to something more reasonable to make use of true caching.

I also tweaked the way options are passed into the `Select2EntityType` to make it easier to expand on this in the future (passing in 6 arguments to the constructor starts to get a little crazy).