### PR TITLE
changing transformers $value checks to use empty() 

### DIFF
--- a/Form/DataTransformer/EntitiesToPropertyTransformer.php
+++ b/Form/DataTransformer/EntitiesToPropertyTransformer.php
@@ -48,7 +48,7 @@ class EntitiesToPropertyTransformer implements DataTransformerInterface
      */
     public function transform($entities)
     {
-        if (is_null($entities) || count($entities) === 0) {
+        if (empty($entities)) {
             return array();
         }
 
@@ -75,7 +75,7 @@ class EntitiesToPropertyTransformer implements DataTransformerInterface
      */
     public function reverseTransform($values)
     {
-        if (!is_array($values) || count($values) === 0) {
+        if (!is_array($values) || empty($values)) {
             return new ArrayCollection();
         }
 

--- a/Form/DataTransformer/EntityToPropertyTransformer.php
+++ b/Form/DataTransformer/EntityToPropertyTransformer.php
@@ -48,7 +48,7 @@ class EntityToPropertyTransformer implements DataTransformerInterface
     public function transform($entity)
     {
         $data = array();
-        if (null === $entity) {
+        if (empty($entity)) {
             return $data;
         }
         $accessor = PropertyAccess::createPropertyAccessor();
@@ -70,7 +70,7 @@ class EntityToPropertyTransformer implements DataTransformerInterface
      */
     public function reverseTransform($value)
     {
-        if (null === $value) {
+        if (empty($value)) {
             return null;
         }
         $repo = $this->em->getRepository($this->className);


### PR DESCRIPTION
Instead of simple null checks. key's can't (shouldn't) be anything that empty() would return true for.

Simply checking for ```null === $value``` means that an empty string was being tried as the key during transformation to an entity. Other values such as 0 should not be used as keys in a database either. changing the empty() fixes this and prevents an erroneous form validation error.
