### PR TITLE
Append empty option if allow_clear set to true - required by select2.js

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -23,7 +23,7 @@
         <select {{ block('widget_attributes') }}>
             {% if value is iterable %}
                 {% if allow_clear %}
-                        <option>{{ placeholder|trans({}, translation_domain) }}</option>
+                        <option value=""></option>
                 {% endif %}
                 {% for id, label in value %}
                     {% block tetranz_select2entity_widget_select_option %}

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -22,6 +22,9 @@
     {% spaceless %}
         <select {{ block('widget_attributes') }}>
             {% if value is iterable %}
+                {% if allow_clear %}
+                        <option>{{ placeholder|trans({}, translation_domain) }}</option>
+                {% endif %}
                 {% for id, label in value %}
                     {% block tetranz_select2entity_widget_select_option %}
                         <option value="{{ id }}" selected="selected">{{ label }}</option>


### PR DESCRIPTION
The allowClear functionality of select2 needs an empty `<option>` tag to work. This issue is not properly described in select2 documentation, but people encounter this problem frequently, e.g. 
[http://stackoverflow.com/questions/32210811/when-using-select2-v-4-0-on-a-jquery-ui-dialog-how-can-i-get-allowclear-optio](url)
