### PR TITLE
Implemented/Fixed infinite scrolling support.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,6 +23,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
                 ->children()
                     ->scalarNode('minimum_input_length')->defaultValue(1)->end()
+                    ->scalarNode('scroll')->defaultFalse()->end()
                     ->scalarNode('page_limit')->defaultValue(10)->end()
                     ->scalarNode('allow_clear')->defaultFalse()->end()
                     ->scalarNode('delay')->defaultValue(250)->end()

--- a/Form/Type/Select2EntityType.php
+++ b/Form/Type/Select2EntityType.php
@@ -110,6 +110,7 @@ class Select2EntityType extends AbstractType
                 'compound' => false,
                 'minimum_input_length' => $this->config['minimum_input_length'],
                 'page_limit' => $this->config['page_limit'],
+                'scroll' => $this->config['scroll'],
                 'allow_clear' => $this->config['allow_clear'],
                 'delay' => $this->config['delay'],
                 'text_property' => null,

--- a/Form/Type/Select2EntityType.php
+++ b/Form/Type/Select2EntityType.php
@@ -74,7 +74,7 @@ class Select2EntityType extends AbstractType
         $view->vars['remote_path'] = $options['remote_path']
             ?: $this->router->generate($options['remote_route'], array_merge($options['remote_params'], [ 'page_limit' => $options['page_limit'] ]));
 
-        $varNames = array_merge(array('multiple', 'placeholder', 'primary_key'), array_keys($this->config));
+        $varNames = array_merge(array('multiple', 'placeholder', 'primary_key', 'page_limit'), array_keys($this->config));
         foreach ($varNames as $varName) {
             $view->vars[$varName] = $options[$varName];
         }

--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ If text_property is omitted then the entity is cast to a string. This requires i
 * `cache_timeout` How long to cache a query in milliseconds. Setting to `0` will cause the cache to never timeout _(60000 = 60 seconds)_
 * `transformer` The fully qualified class name of a custom transformer if you need that flexibility as described below.
 
-The url of the remote query can be given by either of two ways: `remote_route` is the Symfony route. `remote_params` can be optionally specified to provide parameters. Alternatively, `remote_path` can be used to specify the url directly.
+The url of the remote query can be given by either of two ways: `remote_route` is the Symfony route. 
+`remote_params` can be optionally specified to provide parameters. Alternatively, `remote_path` can be used to specify 
+the url directly.
 
 The defaults can be changed in your app/config.yml file with the following format.
 
@@ -143,6 +145,25 @@ The controller should return a `JSON` array in the following format. The propert
   { id: 2, text: 'Displayed Text 2' }
 ]
 ```
+##Ininite Scrolling##
+If your results are being paged via the Select2 "infinite scrolling" feature then you can either continue to return
+the same array as shown above _(for Backwards Compatibility this bundle will automatically try to determine if more 
+results are needed)_, or you can return an object shown below to have finer control over the paged results.
+
+The `more` field should be true if there are more results to be loaded. 
+
+```javascript
+{
+  results: [
+     { id: 1, text: 'Displayed Text 1' },
+     { id: 2, text: 'Displayed Text 2' }
+  ],
+  more: true
+}
+```
+
+Your controller action that fetches the results will receive a parameter `page` indicating what page of results should
+be loaded. _Note: Select2 does not send `page` on the first request._ 
 
 ##Custom option text##
 If you need more flexibility in what you display as the text for each option, such as displaying the values of several fields from your entity or showing an image inside, you may define your own custom transformer.

--- a/Resources/public/js/select2entity.js
+++ b/Resources/public/js/select2entity.js
@@ -4,13 +4,15 @@ $(document).ready(function () {
             // Keep a reference to the element so we can keep the cache local to this instance and so we can
             // determine if caching is even enabled on this element by looking at it's data attributes since select2
             // doesn't expose its options to the transport method.
-            var $s2 = $(this), cache = [];
+            var $s2 = $(this), limit = $s2.data('page-limit') || 0, prefix = Date.now(), cache = [];
             $s2.select2($.extend({
                 ajax: {
                     transport: function (params, success, failure) {
                         // is caching enabled?
                         if ($s2.data('ajax--cache')) {
-                            var key = params.data.q, cacheTimeout = $s2.data('ajax--cacheTimeout');
+                            // try to make the key unique to make it less likely for a page+q to match a real query
+                            var key = prefix + ' page:' + (params.data.page || 1) + ' ' + params.data.q,
+                                cacheTimeout = $s2.data('ajax--cacheTimeout');
                             // no cache entry for 'term' or the cache has timed out?
                             if (typeof cache[key] == 'undefined' || (cacheTimeout && Date.now() >= cache[key].time)) {
                                 $.ajax(params).fail(failure).done(function (data) {
@@ -31,12 +33,33 @@ $(document).ready(function () {
                     },
                     data: function (params) {
                         return {
-                            q: params.term
+                            q: params.term,
+                            page: params.page || 1
                         };
                     },
-                    processResults: function (data) {
+                    processResults: function (data, params) {
+                        var results, more = false;
+                        params.page = params.page || 1;
+
+                        if ($.isArray(data)) {
+                            // maintain BC; assume there is more if the result length == limit
+                            results = data;
+                            more = results.length == limit;
+                        } else if (typeof data == 'object') {
+                            // remote result was proper object
+                            results = data.results;
+                            more = data.more;
+                        } else {
+                            // failsafe
+                            results = [];
+                            more = false;
+                        }
+
                         return {
-                            results: data
+                            results: results,
+                            pagination: {
+                                more: more
+                            }
                         };
                     }
                 }

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -8,6 +8,7 @@
     'data-language':language,
     'data-minimum-input-length':minimum_input_length,
     'data-placeholder':placeholder|trans({}, translation_domain),
+    'data-page-limit':page_limit,
     'class' : (attr.class|default('') ~ ' select2entity form-control')|trim
     }) %}
 

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -9,6 +9,7 @@
     'data-minimum-input-length':minimum_input_length,
     'data-placeholder':placeholder|trans({}, translation_domain),
     'data-page-limit':page_limit,
+    'data-scroll':scroll ? 'true' : 'false',
     'class' : (attr.class|default('') ~ ' select2entity form-control')|trim
     }) %}
 


### PR DESCRIPTION
Infinite scrolling now works. 

In order for a user to support this they must act on the Select2 `page` parameter that is automatically sent in each request (except the first request). For example:

```php
public function lookupAction(Request $request)
  $query = $request->query->get('q');
  $limit = $request->query->get('page_limit');  
  $page = $request->query->get('page') ?: 1;
  $offset = ($page - 1) * $limit;
  $results = $repo->createQuerybuilder('a')
    ->setFirstResult($offset)
    ->setMaxResults($limit)
    ->where('...')
    ->getQuery()
    ->getResult();
```
**No BC breaks**