### PR TITLE
EntityToPropertyTransformer doesn't take primaryKey into account

### DIFF
--- a/Form/DataTransformer/EntitiesToPropertyTransformer.php
+++ b/Form/DataTransformer/EntitiesToPropertyTransformer.php
@@ -2,8 +2,6 @@
 
 namespace Tetranz\Select2EntityBundle\Form\DataTransformer;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
@@ -89,7 +87,7 @@ class EntitiesToPropertyTransformer implements DataTransformerInterface
               ->getQuery()
               ->getResult();
         }
-        catch (DriverException $ex) {
+        catch (\Exception $ex) {
           // this will happen if the form submits invalid data
           throw new TransformationFailedException('One or more id values are invalid');
         }

--- a/Form/DataTransformer/EntityToPropertyTransformer.php
+++ b/Form/DataTransformer/EntityToPropertyTransformer.php
@@ -2,7 +2,6 @@
 
 namespace Tetranz\Select2EntityBundle\Form\DataTransformer;
 
-use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
@@ -12,6 +11,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
  * Data transformer for single mode (i.e., multiple = false)
  *
  * Class EntityToPropertyTransformer
+ *
  * @package Tetranz\Select2EntityBundle\Form\DataTransformer
  */
 class EntityToPropertyTransformer implements DataTransformerInterface
@@ -27,9 +27,9 @@ class EntityToPropertyTransformer implements DataTransformerInterface
 
     /**
      * @param EntityManagerInterface $em
-     * @param string $class
-     * @param string|null $textProperty
-     * @param string $primaryKey
+     * @param string                 $class
+     * @param string|null            $textProperty
+     * @param string                 $primaryKey
      */
     public function __construct(EntityManagerInterface $em, $class, $textProperty = null, $primaryKey = 'id')
     {
@@ -76,11 +76,10 @@ class EntityToPropertyTransformer implements DataTransformerInterface
         $repo = $this->em->getRepository($this->className);
 
         try {
-          $entity = $repo->find($value);
-        }
-        catch(DriverException $ex) {
-          // this will happen if the form submits invalid data
-          throw new TransformationFailedException(sprintf('The choice "%s" does not exist or is not unique', $value));
+            $entity = $repo->findOneBy([$this->primaryKey => $value]);
+        } catch (\Exception $ex) {
+            // this will happen if the form submits invalid data
+            throw new TransformationFailedException(sprintf('The choice "%s" does not exist or is not unique', $value));
         }
 
         if (!$entity) {


### PR DESCRIPTION
`EntityToPropertyTransformer` does not take the `primaryKey` option into account. So it's impossible to fetch entities on anything other than `id`. This simple fix fixes that.

Unrelated, I got rid of a reference to `DriverException`. That exception only exists in Doctrine DBAL 2.5+ and won't necessarily be there (even for Symfony 2.8 installs).  I changed the catch to \Exception instead. The end result is the same with no user-facing changes.