### PR TITLE
Deep-merge Select2 options

### DIFF
--- a/Resources/public/js/select2entity.js
+++ b/Resources/public/js/select2entity.js
@@ -8,7 +8,8 @@
                 scroll = $s2.data('scroll'),
                 prefix = Date.now(),
                 cache = [];
-            $s2.select2($.extend({
+            // Deep-merge the options
+            $s2.select2($.extend(true, {
                 // Tags support
                 createTag: function (data) {
                     if ($s2.data('tags') && data.term.length > 0) {


### PR DESCRIPTION
In order to be able to provide custom options for the nested keys (e.g. `ajax.data`) the options must be recursively merged. Otherwise all other sub-keys must also be provided, or copied.

E.g. if you want to provide custom parameters to the query you can pass such an options object when initialising the `select2entity` plugin:

```
{
    ajax: {
        data: function() {
            // some implementation...
        }
    }
}
```

This will override the custom `transport` and `processResults` methods provided by this bundle and will result in some functionality loss (infinite scroll and cache will not work anymore).