### PR TITLE
Custom entity manager

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -42,6 +42,7 @@ class Configuration implements ConfigurationInterface
                     // be very effective. Realistically this should be like 60000ms (60 seconds).
                     ->scalarNode('cache_timeout')->defaultValue(1)->end()
                     ->scalarNode('width')->defaultNull()->end()
+                    ->scalarNode('object_manager')->defaultValue(1)->end()
                 ->end();
 
         // Here you should define the parameters that are allowed to

--- a/Form/Type/Select2EntityType.php
+++ b/Form/Type/Select2EntityType.php
@@ -42,11 +42,18 @@ class Select2EntityType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        // custom entity manager for this entity ?
-        if(isset($options['em'])) {
-            $em=$options['em'];
+        /* @var $em ObjectManager */
+        $em = null;
+
+        // custom object manager for this entity, override the default entity manager ?
+        if(isset($options['object_manager'])) {
+            $em = $options['object_manager'];
+            if(!$em instanceof ObjectManager) {
+                throw new \Exception('The entity manager \'em\' must be an ObjectManager instance');
+            }
         } else {
-            $em=$this->em;
+            // else, we use the default entity manager
+            $em = $this->em;
         }
 
         // add custom data transformer
@@ -126,7 +133,7 @@ class Select2EntityType extends AbstractType
     {
         $resolver->setDefaults(
             array(
-                'em'=>null,
+                'object_manager'=>null,
                 'class' => null,
                 'primary_key' => 'id',
                 'remote_path' => null,

--- a/Form/Type/Select2EntityType.php
+++ b/Form/Type/Select2EntityType.php
@@ -42,6 +42,13 @@ class Select2EntityType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        // custom entity manager for this entity ?
+        if(isset($options['em'])) {
+            $em=$options['em'];
+        } else {
+            $em=$this->em;
+        }
+
         // add custom data transformer
         if ($options['transformer']) {
             if (!is_string($options['transformer'])) {
@@ -51,7 +58,7 @@ class Select2EntityType extends AbstractType
                 throw new \Exception('Unable to load class: '.$options['transformer']);
             }
 
-            $transformer = new $options['transformer']($this->em, $options['class']);
+            $transformer = new $options['transformer']($em, $options['class']);
 
             if (!$transformer instanceof DataTransformerInterface) {
                 throw new \Exception(sprintf('The custom transformer %s must implement "Symfony\Component\Form\DataTransformerInterface"', get_class($transformer)));
@@ -67,8 +74,8 @@ class Select2EntityType extends AbstractType
             }
 
             $transformer = $options['multiple']
-                ? new EntitiesToPropertyTransformer($this->em, $options['class'], $options['text_property'], $options['primary_key'], $newTagPrefix)
-                : new EntityToPropertyTransformer($this->em, $options['class'], $options['text_property'], $options['primary_key']);
+                ? new EntitiesToPropertyTransformer($em, $options['class'], $options['text_property'], $options['primary_key'], $newTagPrefix)
+                : new EntityToPropertyTransformer($em, $options['class'], $options['text_property'], $options['primary_key']);
         }
 
         $builder->addViewTransformer($transformer, true);
@@ -119,6 +126,7 @@ class Select2EntityType extends AbstractType
     {
         $resolver->setDefaults(
             array(
+                'em'=>null,
                 'class' => null,
                 'primary_key' => 'id',
                 'remote_path' => null,

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ $builder
             'cache_timeout' => 60000, // if 'cache' is true
             'language' => 'en',
             'placeholder' => 'Select a country',
+            // 'em' => $entityManager, // inject a custom entity manager 
         ])
 ```
 Put this at the top of the file with the form type class:


### PR DESCRIPTION
Patch to close #58.

Ability to use a different Entity manager on each Select2Type in a form (useful when working on many databases).