### PR TITLE
Fix Add new tags for single entity

### DIFF
--- a/Form/Type/Select2EntityType.php
+++ b/Form/Type/Select2EntityType.php
@@ -42,20 +42,6 @@ class Select2EntityType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        /* @var $em ObjectManager */
-        $em = null;
-
-        // custom object manager for this entity, override the default entity manager ?
-        if(isset($options['object_manager'])) {
-            $em = $options['object_manager'];
-            if(!$em instanceof ObjectManager) {
-                throw new \Exception('The entity manager \'em\' must be an ObjectManager instance');
-            }
-        } else {
-            // else, we use the default entity manager
-            $em = $this->em;
-        }
-
         // add custom data transformer
         if ($options['transformer']) {
             if (!is_string($options['transformer'])) {
@@ -65,13 +51,13 @@ class Select2EntityType extends AbstractType
                 throw new \Exception('Unable to load class: '.$options['transformer']);
             }
 
-            $transformer = new $options['transformer']($em, $options['class']);
+            $transformer = new $options['transformer']($this->em, $options['class']);
 
             if (!$transformer instanceof DataTransformerInterface) {
                 throw new \Exception(sprintf('The custom transformer %s must implement "Symfony\Component\Form\DataTransformerInterface"', get_class($transformer)));
             }
 
-        // add the default data transformer
+            // add the default data transformer
         } else {
 
             if (isset($options['allow_add']['new_tag_prefix'])) {
@@ -81,8 +67,8 @@ class Select2EntityType extends AbstractType
             }
 
             $transformer = $options['multiple']
-                ? new EntitiesToPropertyTransformer($em, $options['class'], $options['text_property'], $options['primary_key'], $newTagPrefix)
-                : new EntityToPropertyTransformer($em, $options['class'], $options['text_property'], $options['primary_key']);
+                ? new EntitiesToPropertyTransformer($this->em, $options['class'], $options['text_property'], $options['primary_key'], $newTagPrefix)
+                : new EntityToPropertyTransformer($this->em, $options['class'], $options['text_property'], $options['primary_key'], $newTagPrefix);
         }
 
         $builder->addViewTransformer($transformer, true);
@@ -133,7 +119,6 @@ class Select2EntityType extends AbstractType
     {
         $resolver->setDefaults(
             array(
-                'object_manager'=>null,
                 'class' => null,
                 'primary_key' => 'id',
                 'remote_path' => null,


### PR DESCRIPTION
Bugfix for #51 
The support of new tags was limited to multiple entries. This should do the trick for the single entity as well.
Please note I also removed a query in the transform function as it seemed useless but I didn't understand the comment. 
I am happy to modify this if you can provide more insight about the usage. 

Moving forward, it may be of interest to have a parent class as a lot of code is duplicated between EntityToPropertyTransformer and EntitiesToPropertyTransformer.

Thanks!