### PR TITLE
transformers: added missing $accessor property

### DIFF
--- a/Form/DataTransformer/EntitiesToPropertyTransformer.php
+++ b/Form/DataTransformer/EntitiesToPropertyTransformer.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 /**
  * Data transformer for multiple mode (i.e., multiple = true)
@@ -25,6 +26,8 @@ class EntitiesToPropertyTransformer implements DataTransformerInterface
     protected $primaryKey;
     /** @var  string */
     protected $newTaxPrefix;
+    /** @var PropertyAccessor */
+    protected $accessor;
 
     /**
      * @param ObjectManager $em

--- a/Form/DataTransformer/EntityToPropertyTransformer.php
+++ b/Form/DataTransformer/EntityToPropertyTransformer.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 /**
  * Data transformer for single mode (i.e., multiple = false)
@@ -26,6 +27,8 @@ class EntityToPropertyTransformer implements DataTransformerInterface
     protected $primaryKey;
     /** @var string  */
     protected $newTagPrefix;
+    /** @var PropertyAccessor */
+    protected $accessor;
 
     /**
      * @param ObjectManager $em


### PR DESCRIPTION
In both DataTransformers there is a class member `$accessor` created in the constructor.

It is however missing in the class definition, so IDE does not autocomplete when extending the default class.