### PR TITLE
EntityToPropertyTransformer: added missing phpDoc

### DIFF
--- a/Form/DataTransformer/EntityToPropertyTransformer.php
+++ b/Form/DataTransformer/EntityToPropertyTransformer.php
@@ -32,6 +32,7 @@ class EntityToPropertyTransformer implements DataTransformerInterface
      * @param string                 $class
      * @param string|null            $textProperty
      * @param string                 $primaryKey
+     * @param string                 $newTagPrefix
      */
     public function __construct(ObjectManager $em, $class, $textProperty = null, $primaryKey = 'id', $newTagPrefix = '__')
     {


### PR DESCRIPTION
There is a missing phpDoc for the 5th constructor argument `$newTagPrefix`.