### PR TITLE
Check 'callback' option is callable

### DIFF
--- a/Service/AutocompleteService.php
+++ b/Service/AutocompleteService.php
@@ -55,7 +55,7 @@ class AutocompleteService implements ContainerAwareInterface
         ;
 
 
-        if (array_key_exists('callback', $fieldOptions)) {
+        if (is_callable($fieldOptions['callback'])) {
             $cb = $fieldOptions['callback'];
 
             $cb($countQB, $request);


### PR DESCRIPTION
`callback` option [allways exists](https://github.com/tetranz/select2entity-bundle/blob/master/Form/Type/Select2EntityType.php#L171) and as a default is `null`

If we don't need to use the callback, then we get the error [hear](https://github.com/tetranz/select2entity-bundle/blob/master/Service/AutocompleteService.php#L61).

```php
->add('vendor', Select2EntityType::class, [
    'label' => false,
    'remote_route' => 'vendor_autocomplete',
    'class' => Vendor::class,
    'required' => false,
    'property' => 'name',
])
```

Error message:

> Error: Function name must be a string