### PR TITLE
Fix illegal offset type warning

### DIFF
--- a/Form/DataTransformer/EntitiesToPropertyTransformer.php
+++ b/Form/DataTransformer/EntitiesToPropertyTransformer.php
@@ -69,7 +69,7 @@ class EntitiesToPropertyTransformer implements DataTransformerInterface
                 : $this->accessor->getValue($entity, $this->textProperty);
 
             if ($this->em->contains($entity)) {
-                $value = $this->accessor->getValue($entity, $this->primaryKey);
+                $value = (string) $this->accessor->getValue($entity, $this->primaryKey);
             } else {
                 $value = $this->newTagPrefix . $text;
                 $text = $text.$this->newTagText;

--- a/Form/DataTransformer/EntityToPropertyTransformer.php
+++ b/Form/DataTransformer/EntityToPropertyTransformer.php
@@ -68,7 +68,7 @@ class EntityToPropertyTransformer implements DataTransformerInterface
             : $this->accessor->getValue($entity, $this->textProperty);
 
         if ($this->em->contains($entity)) {
-            $value = $this->accessor->getValue($entity, $this->primaryKey);
+            $value = (string) $this->accessor->getValue($entity, $this->primaryKey);
         } else {
             $value = $this->newTagPrefix . $text;
             $text = $text.$this->newTagText;


### PR DESCRIPTION
I cache warning `Illegal offset type` [hear](https://github.com/tetranz/select2entity-bundle/blob/master/Form/DataTransformer/EntityToPropertyTransformer.php#L71) because i use ValueObject as entity id.

Simple fix for this is use `__toString()` method and force convert value to string.