### PR TITLE
prepare formtype for auto remote_route

### DIFF
--- a/Form/Type/Select2EntityType.php
+++ b/Form/Type/Select2EntityType.php
@@ -119,6 +119,8 @@ class Select2EntityType extends AbstractType
         if ($options['multiple']) {
             $view->vars['full_name'] .= '[]';
         }
+
+	    $view->vars['class_type'] = $options['class_type'];
     }
 
     /**
@@ -169,6 +171,7 @@ class Select2EntityType extends AbstractType
                 'req_params' => array(),
                 'property' => null,
                 'callback' => null,
+                'class_type' => null,
             )
         );
     }

--- a/Resources/public/js/select2entity.js
+++ b/Resources/public/js/select2entity.js
@@ -63,7 +63,8 @@
                     data: function (params) {
                         var ret = {
                             'q': params.term,
-                            'field_name': $s2.data('name')
+                            'field_name': $s2.data('name'),
+                            'class_type': $s2.data('classtype')
                         };
 
                         var reqParams = $s2.data('req_params');

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -36,6 +36,10 @@
         {% set attr = attr|merge({'data-width': width}) %}
     {% endif %}
 
+    {% if class_type %}
+        {% set attr = attr|merge({'data-classtype': class_type}) %}
+    {% endif %}
+
 
     {% spaceless %}
         <select {{ block('widget_attributes') }}>


### PR DESCRIPTION
I have change some parts of your bundle to use only one route for all the fields, because you have a service "tetranz_select2entity.autocomplete_service" and a method "getAutocompleteResults(Request $request, $type)"

If you pass via ajax the form class name you can use only one route for generate all the json entities:

```
->add('select_ajax',Select2EntityType::class,array(
				'label'=>'Autocomplete ajax Select 2',
				'placeholder'=>'Seleccione una opción',
				'required' => true,
				'multiple' => false,
				'remote_route' => 'admin_autocomplete',
				'class' => User::class,
				'class_type' => static::class,
			))
```

```
class AutocompleteController extends Controller{

	/**
	 * @Route("/results", name="admin_autocomplete", options={"expose"=true})
	 * @Method("GET")
	 */
	public function AutocompleteAction(Request $request)
	{
		
		$classType = $request->query->get('class_type');
		$as = $this->get('tetranz_select2entity.autocomplete_service');
		$result = $as->getAutocompleteResults($request, $classType);
		return new JsonResponse($result);

	}

}
```