### PR TITLE
Upadate README.md for Symfony 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ twig:
         - 'TetranzSelect2EntityBundle:Form:fields.html.twig'
         
 ```
+On Symfony 4, use `@TetranzSelect2Entity/Form/fields.html.twig` instead of `TetranzSelect2EntityBundle:Form:fields.html.twig`
 * Load the Javascript on the page. The simplest way is to add the following to your layout file. Don't forget to run console assets:install. Alternatively, do something more sophisticated with Assetic.
 ```
 <script src="{{ asset('bundles/tetranzselect2entity/js/select2entity.js') }}"></script>


### PR DESCRIPTION
On Symfony 4, it seems that we should reference to a resource in a different way otherwise we get that error : 
Unable to find template "TetranzSelect2EntityBundle:Form:fields.html.twig"