### PR TITLE
fix root node deprecation in symfony-config > 4.1

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('tetranz_select2_entity');
+        $treeBuilder = new TreeBuilder('tetranz_select2_entity');
+        $rootNode = \method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('tetranz_select2_entity');
 
         $rootNode
                 ->children()


### PR DESCRIPTION
Fixes the deprecation warnings about tree builders without root nodes being deprecated since 4.2.

This fix is BC with 4.1 and older and is similar to the [fix applied to doctrine/DoctrineBundle](https://github.com/doctrine/DoctrineBundle/pull/853/files).

Fixes #135 