### PR TITLE
Return request object.

### DIFF
--- a/Resources/public/js/select2entity.js
+++ b/Resources/public/js/select2entity.js
@@ -40,7 +40,7 @@
                                 cacheTimeout = $s2.data('ajax--cacheTimeout');
                             // no cache entry for 'term' or the cache has timed out?
                             if (typeof cache[key] == 'undefined' || (cacheTimeout && Date.now() >= cache[key].time)) {
-                                $.ajax(params).fail(failure).done(function (data) {
+                                return $.ajax(params).fail(failure).done(function (data) {
                                     cache[key] = {
                                         data: data,
                                         time: cacheTimeout ? Date.now() + cacheTimeout : null


### PR DESCRIPTION
This adds to https://github.com/tetranz/select2entity-bundle/pull/114

See https://select2.org/data-sources/ajax#jquery-ajax-options

The transport function should return an object that has an abort function.