### PR TITLE
fix: using text_property instead of property for view

### DIFF
--- a/Service/AutocompleteService.php
+++ b/Service/AutocompleteService.php
@@ -80,7 +80,7 @@ class AutocompleteService
         $accessor = PropertyAccess::createPropertyAccessor();
 
         $result['results'] = array_map(function ($item) use ($accessor, $fieldOptions) {
-            return ['id' => $accessor->getValue($item, $fieldOptions['primary_key']), 'text' => $accessor->getValue($item, $fieldOptions['property'])];
+            return ['id' => $accessor->getValue($item, $fieldOptions['primary_key']), 'text' => $accessor->getValue($item, $fieldOptions['text_property'])];
         }, $paginationResults);
 
         return $result;


### PR DESCRIPTION
Readme said:

`text_property` This is the entity property used to retrieve the text for existing data. If text_property is omitted then the entity is cast to a string. This requires it to have a __toString() method.

But not used, for front transformation