### PR TITLE
feat: bump php to ">=7.2.5", use new language features of 7.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ app/config/parameters.yml
 
 # Composer
 composer.phar
+composer.lock
 
 #PhpStorm
 .idea

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,7 +15,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('tetranz_select2_entity');
         $rootNode = $treeBuilder->getRootNode();

--- a/DependencyInjection/TetranzSelect2EntityExtension.php
+++ b/DependencyInjection/TetranzSelect2EntityExtension.php
@@ -17,7 +17,7 @@ class TetranzSelect2EntityExtension extends Extension
     /**
      * {@inheritDoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/Form/DataTransformer/EntitiesToPropertyTransformer.php
+++ b/Form/DataTransformer/EntitiesToPropertyTransformer.php
@@ -31,14 +31,7 @@ class EntitiesToPropertyTransformer implements DataTransformerInterface
     /** @var PropertyAccessor */
     protected $accessor;
 
-    /**
-     * @param ObjectManager $em
-     * @param string $class
-     * @param string|null $textProperty
-     * @param string $primaryKey
-     * @param string $newTagPrefix
-     */
-    public function __construct(ObjectManager $em, $class, $textProperty = null, $primaryKey = 'id', $newTagPrefix = '__', $newTagText = ' (NEW)')
+    public function __construct(ObjectManager $em, string $class, ?string $textProperty = null, string $primaryKey = 'id', string $newTagPrefix = '__', $newTagText = ' (NEW)')
     {
         $this->em = $em;
         $this->className = $class;
@@ -53,9 +46,8 @@ class EntitiesToPropertyTransformer implements DataTransformerInterface
      * Transform initial entities to array
      *
      * @param mixed $entities
-     * @return array
      */
-    public function transform($entities)
+    public function transform($entities): array
     {
         if (empty($entities)) {
             return array();
@@ -85,9 +77,8 @@ class EntitiesToPropertyTransformer implements DataTransformerInterface
      * Transform array to a collection of entities
      *
      * @param array $values
-     * @return array
      */
-    public function reverseTransform($values)
+    public function reverseTransform($values): array
     {
         if (!is_array($values) || empty($values)) {
             return array();

--- a/Form/DataTransformer/EntityToPropertyTransformer.php
+++ b/Form/DataTransformer/EntityToPropertyTransformer.php
@@ -32,14 +32,8 @@ class EntityToPropertyTransformer implements DataTransformerInterface
     /** @var PropertyAccessor */
     protected $accessor;
 
-    /**
-     * @param ObjectManager $em
-     * @param string                 $class
-     * @param string|null            $textProperty
-     * @param string                 $primaryKey
-     * @param string                 $newTagPrefix
-     */
-    public function __construct(ObjectManager $em, $class, $textProperty = null, $primaryKey = 'id', $newTagPrefix = '__', $newTagText = ' (NEW)')
+
+    public function __construct(ObjectManager $em, string $class, string $textProperty = null, string $primaryKey = 'id', string $newTagPrefix = '__', $newTagText = ' (NEW)')
     {
         $this->em = $em;
         $this->className = $class;
@@ -54,9 +48,8 @@ class EntityToPropertyTransformer implements DataTransformerInterface
      * Transform entity to array
      *
      * @param mixed $entity
-     * @return array
      */
-    public function transform($entity)
+    public function transform($entity): array
     {
         $data = array();
         if (empty($entity)) {

--- a/Form/Type/Select2EntityType.php
+++ b/Form/Type/Select2EntityType.php
@@ -32,12 +32,7 @@ class Select2EntityType extends AbstractType
     /** @var array */
     protected $config;
 
-    /**
-     * @param ManagerRegistry   $registry
-     * @param RouterInterface   $router
-     * @param array             $config
-     */
-    public function __construct(ManagerRegistry $registry, RouterInterface $router, $config)
+    public function __construct(ManagerRegistry $registry, RouterInterface $router, array $config)
     {
         $this->registry = $registry;
         $this->em = $registry->getManager();
@@ -45,7 +40,7 @@ class Select2EntityType extends AbstractType
         $this->config = $config;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         // custom object manager for this entity, override the default entity manager ?
         if (isset($options['object_manager'])) {
@@ -97,7 +92,7 @@ class Select2EntityType extends AbstractType
         $builder->addViewTransformer($transformer, true);
     }
 
-    public function finishView(FormView $view, FormInterface $form, array $options)
+    public function finishView(FormView $view, FormInterface $form, array $options): void
     {
         parent::finishView($view, $form, $options);
         // make variables available to the view
@@ -134,10 +129,7 @@ class Select2EntityType extends AbstractType
 	    $view->vars['class_type'] = $options['class_type'];
     }
 
-    /**
-     * @param OptionsResolver $resolver
-     */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
                 'object_manager' => null,
@@ -180,10 +172,7 @@ class Select2EntityType extends AbstractType
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'tetranz_select2entity';
     }

--- a/Service/AutocompleteService.php
+++ b/Service/AutocompleteService.php
@@ -21,10 +21,6 @@ class AutocompleteService
      */
     private $doctrine;
 
-    /**
-     * @param FormFactoryInterface $formFactory
-     * @param ManagerRegistry      $doctrine
-     */
     public function __construct(FormFactoryInterface $formFactory, ManagerRegistry $doctrine)
     {
         $this->formFactory = $formFactory;
@@ -32,12 +28,9 @@ class AutocompleteService
     }   
 
     /**
-     * @param Request                  $request
      * @param string|FormTypeInterface $type
-     *
-     * @return array
      */
-    public function getAutocompleteResults(Request $request, $type)
+    public function getAutocompleteResults(Request $request, $type): array
     {
         $form = $this->formFactory->create($type);
         $fieldOptions = $form->get($request->get('field_name'))->getConfig()->getOptions();

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1.3",
+        "php": ">=7.2.5",
         "doctrine/orm": ">=2.4",
         "twig/twig": ">=2.9",
         "symfony/property-access": ">=4.0",


### PR DESCRIPTION
Usage stats of 3.1 show 0.x% for php 7.1
https://packagist.org/packages/tetranz/select2entity-bundle/php-stats#3.1

Should be >= 7.4 (but that would exclude 8% of users to upgrade). So i am not sure if it alreday time for this. 
WDYT?


https://github.com/tetranz/select2entity-bundle/pull/183