### PR TITLE
Symfony 7.0 DataTransformerInterface typing support DataTransformers

### DIFF
--- a/Form/DataTransformer/EntitiesToPropertyTransformer.php
+++ b/Form/DataTransformer/EntitiesToPropertyTransformer.php
@@ -52,18 +52,18 @@ class EntitiesToPropertyTransformer implements DataTransformerInterface
     /**
      * Transform initial entities to array
      *
-     * @param mixed $entities
+     * @param mixed $value
      * @return array
      */
-    public function transform($entities)
+    public function transform(mixed $value): mixed
     {
-        if (empty($entities)) {
+        if (empty($value)) {
             return array();
         }
 
         $data = array();
 
-        foreach ($entities as $entity) {
+        foreach ($value as $entity) {
             $text = is_null($this->textProperty)
                 ? (string) $entity
                 : $this->accessor->getValue($entity, $this->textProperty);
@@ -87,7 +87,7 @@ class EntitiesToPropertyTransformer implements DataTransformerInterface
      * @param array $values
      * @return array
      */
-    public function reverseTransform($values)
+    public function reverseTransform(mixed $values): mixed
     {
         if (!is_array($values) || empty($values)) {
             return array();

--- a/Form/DataTransformer/EntityToPropertyTransformer.php
+++ b/Form/DataTransformer/EntityToPropertyTransformer.php
@@ -53,22 +53,22 @@ class EntityToPropertyTransformer implements DataTransformerInterface
     /**
      * Transform entity to array
      *
-     * @param mixed $entity
+     * @param mixed $value
      * @return array
      */
-    public function transform($entity)
+    public function transform(mixed $value): mixed
     {
         $data = array();
-        if (empty($entity)) {
+        if (empty($value)) {
             return $data;
         }
 
         $text = is_null($this->textProperty)
-            ? (string) $entity
-            : $this->accessor->getValue($entity, $this->textProperty);
+            ? (string) $value
+            : $this->accessor->getValue($value, $this->textProperty);
 
-        if ($this->em->contains($entity)) {
-            $value = (string) $this->accessor->getValue($entity, $this->primaryKey);
+        if ($this->em->contains($value)) {
+            $value = (string) $this->accessor->getValue($value, $this->primaryKey);
         } else {
             $value = $this->newTagPrefix . $text;
             $text = $text.$this->newTagText;
@@ -85,7 +85,7 @@ class EntityToPropertyTransformer implements DataTransformerInterface
      * @param string $value
      * @return mixed|null|object
      */
-    public function reverseTransform($value)
+    public function reverseTransform(mixed $value): mixed
     {
         if (empty($value)) {
             return null;


### PR DESCRIPTION
Recently upgraded to symfony 7.0 with this package installed and noticed the error: 
`Compile Error: Declaration of Tetranz\Select2EntityBundle\Form\DataTransformer\EntitiesToPropertyTransformer::transform($value) must be compatible with Symfony\Component\Form\DataTransformerInterface::transform(mixed $value): mixed`

This interface expects native types in the params and return types of this class.